### PR TITLE
Make clear that nvm per se must be installed separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 ```fish
 $ omf install nvm
 ```
+**NB** You have to install **nvm** itself separately (the [curl method](https://github.com/creationix/nvm/blob/master/README.markdown#install-script) works fine under Fish too).
 
 
 ## Usage

--- a/functions/nvm.fish
+++ b/functions/nvm.fish
@@ -7,7 +7,7 @@ function nvm -d "Node version manager"
 
     fenv source $nvm_prefix/nvm.sh\; nvm $argv
   else
-    echo "You need to install nvm"
+    echo "You need to install nvm itself (see https://github.com/creationix/nvm#installation)"
     return 1
   end
 end


### PR DESCRIPTION
As a newcomer, right after running `omf install nvm` it took me a few minutes to accept that the _"You need to install nvm"_ was not making fun of me.